### PR TITLE
chore(package.json): change sintax to test on aws ec2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:babies": "yarn workspace @childcare-hub/babies test",
     "test:users": "yarn workspace @childcare-hub/users test",
     "build:babies": "yarn workspace @childcare-hub/babies build",
-    "docker:services": "docker compose -f docker/docker-compose.dev.yml up mysql rabbitmq mongo"
+    "docker:services": "docker-compose -f docker/docker-compose.dev.yml up mysql rabbitmq mongo"
   },
   "devDependencies": {
     "concurrently": "^6.4.0"


### PR DESCRIPTION
Parece q o Amazon Linux da AWS não aceita essa sintaxe mais recente, alterando pra fazer uns testes.